### PR TITLE
Fix memory leaks, corruption, and warnings

### DIFF
--- a/objc-promise/Promise.m
+++ b/objc-promise/Promise.m
@@ -76,7 +76,7 @@
 
 + (Promise *)resolved:(id)result
 {
-    Deferred *deferred = [[Deferred alloc] init];
+    Deferred *deferred = [[[Deferred alloc] init] autorelease];
     
     [deferred resolve:result];
     
@@ -85,7 +85,7 @@
 
 + (Promise *)rejected:(NSError *)reason
 {
-    Deferred *deferred = [[Deferred alloc] init];
+    Deferred *deferred = [[[Deferred alloc] init] autorelease];
     
     [deferred reject:reason];
     

--- a/objc-promise/Promise.m
+++ b/objc-promise/Promise.m
@@ -180,7 +180,7 @@
     __block Promise *this = self;
     
     // retain the block until we can call with the result
-    Block_copy(resolvedBlock);
+    resolvedBlock = Block_copy(resolvedBlock);
     
     [this bindOrCallBlock:^{
         if (this.isResolved) {
@@ -198,7 +198,7 @@
     __block Promise *this = self;
     
     // retain the block until we can call with the result
-    Block_copy(rejectedBlock);
+    rejectedBlock = Block_copy(rejectedBlock);
     
     [this bindOrCallBlock:^{
         if (this.isRejected) {
@@ -216,7 +216,7 @@
     __block Promise *this = self;
     
     // retain the block until we can call with the result
-    Block_copy(anyBlock);
+    anyBlock = Block_copy(anyBlock);
     
     [this bindOrCallBlock:^{
         anyBlock();

--- a/objc-promise/Promise.m
+++ b/objc-promise/Promise.m
@@ -16,9 +16,12 @@
     if (self = [super init]) {
         _callbackBindings = [[NSMutableArray alloc] init];
         _state = Incomplete;
-        
-        _queue = [queue retain];
-        
+
+        if (queue) {
+            dispatch_retain(queue);
+            _queue = queue;
+        }
+
         _stateLock = [[NSObject alloc] init];
         _result = nil;
     }
@@ -107,10 +110,12 @@
     
     [_reason release];
     _reason = nil;
-    
-    [_queue release];
-    _queue = nil;
-    
+
+    if (_queue) {
+        dispatch_release(_queue);
+        _queue = nil;
+    }
+
     [super dealloc];
 }
 

--- a/objc-promise/Promise.m
+++ b/objc-promise/Promise.m
@@ -178,16 +178,11 @@
 - (Promise *)when:(resolved_block)resolvedBlock
 {
     __block Promise *this = self;
-    
-    // retain the block until we can call with the result
-    resolvedBlock = Block_copy(resolvedBlock);
-    
+
     [this bindOrCallBlock:^{
         if (this.isResolved) {
             resolvedBlock(this.result);
         }
-        
-        Block_release(resolvedBlock);
     }];
     
     return this;
@@ -197,15 +192,10 @@
 {
     __block Promise *this = self;
     
-    // retain the block until we can call with the result
-    rejectedBlock = Block_copy(rejectedBlock);
-    
     [this bindOrCallBlock:^{
         if (this.isRejected) {
             rejectedBlock(this.reason);
         }
-        
-        Block_release(rejectedBlock);
     }];
     
     return this;
@@ -215,13 +205,8 @@
 {
     __block Promise *this = self;
     
-    // retain the block until we can call with the result
-    anyBlock = Block_copy(anyBlock);
-    
     [this bindOrCallBlock:^{
         anyBlock();
-        
-        Block_release(anyBlock);
     }];
     
     return this;


### PR DESCRIPTION
This PR fixes a major issue, a minor issue, and a warning.

Most importantly, it eliminates the Block_copy and Block_release calls in the when/failed/any methods. The Block_copy result was being ignored, which was leading to an over-release of arbitrary stack values when the block was finally run (basically: random segfaults in arbitrary code). Block_copy is actually not necessary here at all, since the block parameters will be copied recursively if the block passed to "bindOrCallBlock" is Block_copy'd before being added to the _callbackBindings array.

It fixes a minor refcount issue by autoreleasing the resolved / rejected return values (found via clang Analyze).

Finally, it switches from retain / release messages on the GCD queues to calling the GCD reference count methods directly, which got rid of a warning in Xcode 4.6.
