### PR TITLE
Pass all values when resolving combined promise

### DIFF
--- a/objc-promise/Promise.m
+++ b/objc-promise/Promise.m
@@ -140,9 +140,14 @@
         [promise when:^(id result) {
             resolvedCount++;
             
-            // all promises have resolved, resolve our promise
+            // all promises have resolved, 
+            // resolve our promise with all values
             if (resolvedCount == count) {
-                [deferred resolve:result];
+                NSMutableArray *finalResult =
+                    [NSMutableArray arrayWithCapacity:count];
+                for (Promise *promise in promises)
+                    [finalResult addObject:promise.result];
+                [deferred resolve:finalResult];
             }
         } failed:^(NSError *error){
             [deferred reject:error];


### PR DESCRIPTION
A combined promise currently only returns the final result and drops all previous results. It should pass the results of  all promises as an array.
