### PR TITLE
Use NSUInteger instead of int (silence warnings)

### DIFF
--- a/objc-promise/Promise.m
+++ b/objc-promise/Promise.m
@@ -156,8 +156,8 @@
 
 + (Promise *)or:(NSArray *)promises
 {
-    int count = promises.count;
-    __block int rejectedCount = 0;
+    NSUInteger count = promises.count;
+    __block NSUInteger rejectedCount = 0;
     Deferred *deferred = [[Deferred alloc] init];
     
     // any promise resolves our deferred
@@ -179,7 +179,7 @@
 
 + (Promise *)and:(NSArray *)promises
 {
-    int count = promises.count;
+    NSUInteger count = promises.count;
     __block int resolvedCount = 0;
     Deferred *deferred = [[Deferred alloc] init];
     


### PR DESCRIPTION
As requested, here's a pull request that changes a type to silence some warnings. Tests continue to pass.
