### PR TITLE
fixed warnings for lack of precision when building promise for 64-bit.

### DIFF
--- a/objc-promise/Promise.m
+++ b/objc-promise/Promise.m
@@ -156,8 +156,8 @@
 
 + (Promise *)or:(NSArray *)promises
 {
-    int count = promises.count;
-    __block int rejectedCount = 0;
+    NSUInteger count = promises.count;
+    __block NSUInteger rejectedCount = 0;
     Deferred *deferred = [[Deferred alloc] init];
     
     // any promise resolves our deferred
@@ -179,8 +179,8 @@
 
 + (Promise *)and:(NSArray *)promises
 {
-    int count = promises.count;
-    __block int resolvedCount = 0;
+    NSUInteger count = promises.count;
+    __block NSUInteger resolvedCount = 0;
     Deferred *deferred = [[Deferred alloc] init];
     
     // any promise resolves our deferred


### PR DESCRIPTION
The collection returns an NSUInteger for -count.

From apple's Header:

```
#if __LP64__ || (TARGET_OS_EMBEDDED && !TARGET_OS_IPHONE) || TARGET_OS_WIN32 || NS_BUILD_32_LIKE_64
typedef long NSInteger;
typedef unsigned long NSUInteger;
#else
typedef int NSInteger;
typedef unsigned int NSUInteger;
#endif
```

As such casting this message to int on a 64-bit build produces a warning about a lack of precision in the receiving type. Fixed by using the NSUInteger type. 
